### PR TITLE
Fix 'onDestroy' not been called + 'findeOne' more stable in dynamic dom/controller structures

### DIFF
--- a/src/excellent.js
+++ b/src/excellent.js
@@ -1443,7 +1443,8 @@
             if (a.length !== 1) {
                 var s = 'Expected a single controller from findOne(' + jStr(name) + '), but found ' + a.length + '.';
                 if(a.length !== 0) s = s + ' First found controller will be returned. Better use ".find()" instead!';
-                console.warn ? console.warn(s) : console.log(s)
+                /* eslint-disable-next-line no-console */
+                console.warn ? console.warn(s) : console.log(s);
             }
             return a[0];
         };
@@ -1956,6 +1957,7 @@
         if (a.length !== 1) {
             var s = 'Expected a single controller from ' + jStr(this.name) + '.findOne(' + jStr(name) + '), but found ' + a.length + '.';
             if(a.length !== 0) s = s + ' First found controller will be returned. Better use ".find()" instead!';
+            /* eslint-disable-next-line no-console */
             console.warn ? console.warn(s) : console.log(s);
         }
         return a[0];

--- a/src/excellent.js
+++ b/src/excellent.js
@@ -547,7 +547,7 @@
             // MutationObserver does not exist in JEST:
             // istanbul ignore if
             if (mo) {
-                mo.observe(e, {childList: true});
+                mo.observe(e, {childList: true, subtree: true});
             }
         };
 
@@ -565,6 +565,7 @@
                         }
                         removeControllers(e);
                     }
+                    manualCheck();
                 }
             });
         }

--- a/src/excellent.js
+++ b/src/excellent.js
@@ -1441,7 +1441,9 @@
         this.findOne = function (name) {
             var a = this.find(name);
             if (a.length !== 1) {
-                throw new Error('Expected a single controller from findOne(' + jStr(name) + '), but found ' + a.length + '.');
+                var s = 'Expected a single controller from findOne(' + jStr(name) + '), but found ' + a.length + '.';
+                if(a.length !== 0) s = s + ' First found controller will be returned. Better use ".find()" instead!';
+                console.warn ? console.warn(s) : console.log(s)
             }
             return a[0];
         };
@@ -1952,7 +1954,9 @@
     EController.prototype.findOne = function (name) {
         var a = this.find(name);
         if (a.length !== 1) {
-            throw new Error('Expected a single controller from ' + jStr(this.name) + '.findOne(' + jStr(name) + '), but found ' + a.length + '.');
+            var s = 'Expected a single controller from ' + jStr(this.name) + '.findOne(' + jStr(name) + '), but found ' + a.length + '.';
+            if(a.length !== 0) s = s + ' First found controller will be returned. Better use ".find()" instead!';
+            console.warn ? console.warn(s) : console.log(s);
         }
         return a[0];
     };


### PR DESCRIPTION
Will call 'onDestroy' on all subordinate controllers if superordinate excellent controlled nodes will be removed from DOM.
'findeOne' (both!) will just log waring if one controller can not be found (0 or >1, but does not throw an error anymore which stops excecuting the rest of JS code in the browser.
